### PR TITLE
feat: Add Navidrome song request feature

### DIFF
--- a/bot/func_helper/navidrome.py
+++ b/bot/func_helper/navidrome.py
@@ -1,0 +1,329 @@
+# -*- coding: utf-8 -*-
+"""
+Navidrome API (Subsonic API) Client
+"""
+import asyncio
+import hashlib
+import random
+import string
+from functools import wraps
+
+import aiohttp
+from aiohttp_retry import RetryClient, ExponentialRetry
+
+from bot import LOGGER,config
+
+# --- Configuration ---
+NAVIDROME_URL = config.navidrome.get('navidrome_url')
+NAVIDROME_USERNAME = config.navidrome.get('navidrome_username')
+NAVIDROME_PASSWORD = config.navidrome.get('navidrome_password')
+NAVIDROME_APP_NAME = config.navidrome.get('navidrome_app_name', 'SakuraEmbyBossBot')
+SUBSONIC_API_VERSION = "1.16.1"  # Common Subsonic API version
+RESPONSE_FORMAT = "json"
+
+# --- Helper Functions ---
+def generate_salt(length=6):
+    """Generates a random alphanumeric salt."""
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
+
+def generate_token(password, salt):
+    """Generates the Subsonic API token (md5(password + salt))."""
+    if not password:
+        return None
+    salted_password = password + salt
+    return hashlib.md5(salted_password.encode('utf-8')).hexdigest()
+
+# --- AIOHTTP Retry Decorator ---
+def aiohttp_retry_for_navidrome(func):
+    """
+    Decorator to add retry logic to aiohttp requests for Navidrome.
+    """
+    @wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        # self here is the NavidromeAPI instance
+        if not self.session or self.session.closed:
+            self.session = aiohttp.ClientSession()
+            LOGGER.info("NavidromeAPI: New aiohttp.ClientSession created.")
+
+        retry_options = ExponentialRetry(attempts=3, excepciones_ignorar=(aiohttp.ClientResponseError,))
+        retry_client = RetryClient(client_session=self.session, retry_options=retry_options)
+        
+        # Pass the retry_client to the decorated function if it expects it,
+        # or use it directly here if the function is part of the class.
+        # For this structure, we'll assume the method uses self.session which is now retry-enabled via context
+        async with retry_client: # Use the retry_client for the session context
+            return await func(self, *args, **kwargs)
+
+    return wrapper
+
+
+# --- Navidrome API Client Class ---
+class NavidromeAPI:
+    """
+    Asynchronous client for interacting with the Navidrome API (Subsonic).
+    """
+    def __init__(self, base_url, username, password, app_name="NavidromeBot", api_version="1.16.1", response_format="json"):
+        if not base_url or not username: # Password can be empty for some public servers initially
+            LOGGER.error("NavidromeAPI: URL and Username are required.")
+            raise ValueError("Navidrome URL and Username are required.")
+        
+        self.base_url = base_url.rstrip('/')
+        self.username = username
+        self.password = password # Store password to generate token per request with new salt
+        self.app_name = app_name
+        self.api_version = api_version
+        self.response_format = response_format
+        self.session = None # Initialized in methods or when first needed
+        LOGGER.info(f"NavidromeAPI initialized for URL: {self.base_url}, User: {self.username}")
+
+    async def _get_session(self):
+        """Gets or creates an aiohttp ClientSession."""
+        if self.session is None or self.session.closed:
+            self.session = aiohttp.ClientSession()
+            LOGGER.info("NavidromeAPI: New aiohttp.ClientSession created for instance.")
+        return self.session
+
+    def _get_auth_params(self):
+        """Generates authentication parameters (salt and token) for a request."""
+        salt = generate_salt()
+        token = generate_token(self.password, salt)
+        if not token: # If password is not set, don't send token/salt
+            return {}
+        return {"s": salt, "t": token}
+
+    @aiohttp_retry_for_navidrome
+    async def _make_request(self, endpoint, params=None, is_json_response=True):
+        """
+        Makes an asynchronous GET request to a Navidrome endpoint.
+
+        :param endpoint: The API endpoint (e.g., "/rest/ping.view").
+        :param params: A dictionary of query parameters for the request.
+        :param is_json_response: Whether to expect a JSON response.
+        :return: Parsed JSON response as a dictionary, or raw content if not JSON.
+        """
+        session = await self._get_session()
+        
+        url = f"{self.base_url}{endpoint}"
+        
+        base_params = {
+            "u": self.username,
+            "v": self.api_version,
+            "c": self.app_name,
+            "f": self.response_format,
+        }
+        # Add auth params (token and salt) if password is provided
+        if self.password:
+            base_params.update(self._get_auth_params())
+
+        if params:
+            base_params.update(params)
+
+        try:
+            LOGGER.debug(f"NavidromeAPI Request: GET {url} with params: {base_params}")
+            async with session.get(url, params=base_params) as response:
+                response.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
+                if is_json_response:
+                    # Check content type before parsing
+                    if "application/json" in response.headers.get("Content-Type", "").lower():
+                        data = await response.json()
+                        LOGGER.debug(f"NavidromeAPI JSON Response: {data}")
+                        if "subsonic-response" in data and data["subsonic-response"].get("status") == "failed":
+                            error_msg = data["subsonic-response"].get("error", {}).get("message", "Unknown Navidrome API error")
+                            LOGGER.error(f"Navidrome API Error: {error_msg} for endpoint {endpoint}")
+                            return {"error": error_msg, "status": "failed"} # Propagate error structure
+                        return data
+                    else:
+                        text_data = await response.text()
+                        LOGGER.error(f"NavidromeAPI Error: Expected JSON but received Content-Type: {response.headers.get('Content-Type')}. Response text: {text_data[:200]}...")
+                        return {"error": "Invalid content type, expected JSON", "status": "failed"}
+                else:
+                    content = await response.read() # For binary data like images
+                    LOGGER.debug(f"NavidromeAPI Binary Response: {len(content)} bytes from {endpoint}")
+                    return content
+        except aiohttp.ClientResponseError as e: # Handles 4xx/5xx from raise_for_status
+            LOGGER.error(f"NavidromeAPI HTTP Error: {e.status} {e.message} for {url}. Response: {await response.text() if response else 'No response text'}")
+            return {"error": f"HTTP {e.status}: {e.message}", "status": "failed"}
+        except aiohttp.ClientError as e: # Handles other client errors (connection, timeout, etc.)
+            LOGGER.error(f"NavidromeAPI Client Error: {e} for {url}")
+            return {"error": str(e), "status": "failed"}
+        except asyncio.TimeoutError:
+            LOGGER.error(f"NavidromeAPI Timeout Error for {url}")
+            return {"error": "Request timed out", "status": "failed"}
+
+    async def ping(self):
+        """
+        Pings the Navidrome server to check connectivity.
+        Endpoint: /rest/ping.view
+        """
+        LOGGER.info("Pinging Navidrome server...")
+        response = await self._make_request("/rest/ping.view")
+        if response and response.get("subsonic-response", {}).get("status") == "ok":
+            LOGGER.info("Navidrome ping successful.")
+            return response
+        else:
+            LOGGER.error(f"Navidrome ping failed. Response: {response}")
+            return response # Return the error structure
+
+    async def search3(self, query, artist_count=5, album_count=5, song_count=10):
+        """
+        Searches for artists, albums, and songs.
+        Endpoint: /rest/search3.view
+        """
+        if not query:
+            LOGGER.error("NavidromeAPI search3: Query cannot be empty.")
+            return {"error": "Query cannot be empty", "status": "failed"}
+
+        params = {
+            "query": query,
+            "artistCount": artist_count,
+            "albumCount": album_count,
+            "songCount": song_count,
+            # Subsonic API also has musicFolderId, if needed in future
+        }
+        LOGGER.info(f"Searching Navidrome for '{query}'...")
+        return await self._make_request("/rest/search3.view", params=params)
+
+    async def get_cover_art(self, cover_id, size=None):
+        """
+        Retrieves cover art for a given ID.
+        Endpoint: /rest/getCoverArt.view
+        Returns raw image data (bytes).
+        """
+        if not cover_id:
+            LOGGER.error("NavidromeAPI get_cover_art: Cover ID cannot be empty.")
+            return None # Or raise error, or return specific error marker
+
+        params = {"id": cover_id}
+        if size:
+            params["size"] = size
+        
+        LOGGER.info(f"Fetching Navidrome cover art for ID: {cover_id} (size: {size or 'original'})")
+        image_bytes = await self._make_request("/rest/getCoverArt.view", params=params, is_json_response=False)
+        
+        # Check if the response is bytes (success) or dict (error from _make_request)
+        if isinstance(image_bytes, dict) and "error" in image_bytes:
+            LOGGER.error(f"Failed to fetch cover art {cover_id}: {image_bytes['error']}")
+            return None
+        elif not isinstance(image_bytes, bytes):
+            LOGGER.error(f"Failed to fetch cover art {cover_id}: Unexpected response type {type(image_bytes)}")
+            return None
+            
+        return image_bytes
+
+    async def close_session(self):
+        """Closes the aiohttp ClientSession."""
+        if self.session and not self.session.closed:
+            await self.session.close()
+            LOGGER.info("NavidromeAPI: aiohttp.ClientSession closed.")
+
+# --- Global Navidrome API Client Instance ---
+navidrome_api = None
+if NAVIDROME_URL and NAVIDROME_USERNAME: # Password can be optional for some setups or if only public info is accessed
+    try:
+        navidrome_api = NavidromeAPI(
+            base_url=NAVIDROME_URL,
+            username=NAVIDROME_USERNAME,
+            password=NAVIDROME_PASSWORD, # Will be None if not set in config
+            app_name=NAVIDROME_APP_NAME,
+            api_version=SUBSONIC_API_VERSION,
+            response_format=RESPONSE_FORMAT
+        )
+        LOGGER.info("Global Navidrome API client initialized.")
+    except ValueError as e: # From NavidromeAPI __init__
+        LOGGER.error(f"Failed to initialize global Navidrome API client: {e}")
+    except Exception as e:
+        LOGGER.error(f"An unexpected error occurred during global Navidrome API client initialization: {e}", exc_info=True)
+else:
+    if not config.navidrome.get('navidrome_url'): # Only log if it looks like user intended to set it up
+        LOGGER.info("Navidrome URL not configured. Global Navidrome API client not initialized.")
+    elif not config.navidrome.get('navidrome_username'):
+        LOGGER.info("Navidrome Username not configured. Global Navidrome API client not initialized.")
+
+
+# --- Example Usage (for testing, can be removed or commented out) ---
+async def main_test():
+    if not navidrome_api:
+        LOGGER.error("Navidrome API client not available for testing.")
+        return
+
+    LOGGER.info("--- Testing Navidrome API ---")
+    
+    # Test Ping
+    ping_response = await navidrome_api.ping()
+    LOGGER.info(f"Ping Response: {ping_response}")
+
+    if ping_response and ping_response.get("subsonic-response", {}).get("status") == "ok":
+        # Test Search (only if ping is ok)
+        search_query = "Michael Jackson" # Replace with a relevant query for your library
+        search_results = await navidrome_api.search3(query=search_query)
+        LOGGER.info(f"Search Results for '{search_query}': {search_results}")
+
+        if search_results and search_results.get("subsonic-response", {}).get("status") == "ok":
+            results = search_results["subsonic-response"].get("searchResult3")
+            if results:
+                if results.get("album"):
+                    first_album_id = results["album"][0].get("coverArt") if results["album"][0].get("coverArt") else results["album"][0].get("id")
+                    if first_album_id: # Navidrome often uses 'id' for coverArt if coverArt field is missing
+                        LOGGER.info(f"Attempting to fetch cover art for ID: {first_album_id}")
+                        cover_image = await navidrome_api.get_cover_art(cover_id=first_album_id, size=200)
+                        if cover_image:
+                            LOGGER.info(f"Cover art fetched successfully: {len(cover_image)} bytes.")
+                            # with open(f"cover_{first_album_id.replace('-','')}.png", "wb") as f:
+                            #     f.write(cover_image)
+                            # LOGGER.info(f"Saved cover art as cover_{first_album_id.replace('-','')}.png")
+                        else:
+                            LOGGER.error("Failed to fetch cover art.")
+                    else:
+                        LOGGER.info("No cover art ID found for the first album.")
+                else:
+                    LOGGER.info("No albums found in search results to test getCoverArt.")
+            else:
+                LOGGER.info("No 'searchResult3' field in search response.")
+    else:
+        LOGGER.error("Skipping further tests as Ping failed.")
+
+    await navidrome_api.close_session()
+    LOGGER.info("--- Navidrome API Test Finished ---")
+
+if __name__ == "__main__":
+    # This is for direct script execution testing.
+    # You'd need to ensure bot.py or equivalent has loaded config.
+    # For simplicity, we'll assume config is loaded if run this way.
+    # A more robust way would be to load config here if __main__.
+    
+    # Configure logging for standalone testing
+    import logging
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    # Assuming config is loaded by bot.py or a similar entry point.
+    # If running this file directly, you might need to mock or manually load `bot.config`.
+    # For example, by creating a dummy config object:
+    # class DummyConfig:
+    #     class NavidromeConfig:
+    #         navidrome_url = "YOUR_NAVIDROME_URL"
+    #         navidrome_username = "YOUR_NAVIDROME_USERNAME"
+    #         navidrome_password = "YOUR_NAVIDROME_PASSWORD"
+    #         navidrome_app_name = "TestApp"
+    #     navidrome = NavidromeConfig()
+    # config = DummyConfig()
+    #
+    # # Then re-initialize the client for testing
+    # if config.navidrome.navidrome_url and config.navidrome.navidrome_username:
+    #     navidrome_api = NavidromeAPI(
+    #         base_url=config.navidrome.navidrome_url,
+    #         username=config.navidrome.navidrome_username,
+    #         password=config.navidrome.navidrome_password,
+    #         app_name=config.navidrome.navidrome_app_name
+    #     )
+    #     asyncio.run(main_test())
+    # else:
+    #     print("Please configure dummy Navidrome settings in the script for __main__ test.")
+    
+    # Current assumption: this script is part of a larger bot and `config` is already populated.
+    # The `if __name__ == "__main__":` block is primarily for illustrative testing.
+    # To run it: python -m bot.func_helper.navidrome
+    # (This might require adjustments to PYTHONPATH or how `bot.config` is accessed)
+    
+    LOGGER.info("To test this module directly, ensure bot.config is populated and uncomment asyncio.run(main_test()) call with appropriate setup.")
+    # Example:
+    # asyncio.run(main_test()) # Make sure config is loaded before this.
+    pass

--- a/bot/modules/panel/__init__.py
+++ b/bot/modules/panel/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ['admin_panel', 'config_panel', 'kk', 'member_panel', 'sched_panel', 'server_panel', 'request_movie_panel']
+__all__ = ['admin_panel', 'config_panel', 'kk', 'member_panel', 'sched_panel', 'server_panel', 'request_movie_panel', 'request_song_panel']
 
-from . import admin_panel, config_panel, kk, member_panel, sched_panel, server_panel, request_movie_panel
+from . import admin_panel, config_panel, kk, member_panel, sched_panel, server_panel, request_movie_panel, request_song_panel

--- a/bot/modules/panel/request_song_panel.py
+++ b/bot/modules/panel/request_song_panel.py
@@ -1,0 +1,476 @@
+# -*- coding: utf-8 -*-
+"""
+Panel for requesting songs via Navidrome.
+"""
+import asyncio
+from io import BytesIO
+
+from pyrogram import filters
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+from bot import bot, LOGGER, config
+from bot.func_helper.navidrome import navidrome_api
+from bot.func_helper.msg_utils import (
+    sendMessage, 
+    editMessage, 
+    deleteMessage,
+    sendPhoto, 
+    callAnswer, 
+    callListen,
+    auto_delete_message
+)
+from bot.func_helper.filters import user_in_group_on_filter # Assuming similar filter as movie panel
+from bot.func_helper.fix_bottons import বাট<y_bin_725> # For button creation, assuming this is the button helper
+
+# --- Constants ---
+ITEMS_PER_PAGE = 5 # Number of items (songs/albums) to display per page
+SONG_SEARCH_TIMEOUT = 120 # seconds for the search interaction to timeout
+
+# --- State Management ---
+# Stores user-specific search state: {user_id: {"query": str, "page": int, "results": dict, "message_id": int, "type": "song"/"album"/"artist"}}
+user_song_search_data = {}
+
+# --- Helper Functions ---
+async def cleanup_user_search_state(user_id):
+    """Clears search state for a user."""
+    if user_id in user_song_search_data:
+        del user_song_search_data[user_id]
+        LOGGER.info(f"Navidrome Panel: Cleaned up search state for user {user_id}")
+
+def format_song_details(song):
+    title = song.get('title', 'N/A')
+    artist = song.get('artist', 'N/A')
+    album = song.get('album', 'N/A')
+    duration = song.get('duration', 0)
+    minutes = duration // 60
+    seconds = duration % 60
+    return f"🎵 **{title}**\n   🎤 Artist: {artist}\n   💿 Album: {album}\n   ⏱ Duration: {minutes}:{seconds:02d}"
+
+def format_album_details(album):
+    title = album.get('name', album.get('title', 'N/A')) # Navidrome uses 'name' for album in searchResult3, 'title' in getAlbum
+    artist = album.get('artist', 'N/A')
+    song_count = album.get('songCount', 'N/A')
+    year = album.get('year', 'N/A')
+    return f"💿 **{title}**\n   🎤 Artist: {artist}\n   🗓 Year: {year}\n   🎶 Songs: {song_count}"
+
+def format_artist_details(artist):
+    name = artist.get('name', 'N/A')
+    album_count = artist.get('albumCount', 'N/A') # from getArtists
+    # SearchResult3 for artist doesn't have albumCount, may need separate getArtist call if detailed info needed here
+    return f"🎤 **{name}**"
+
+
+# --- Main Command Handler ---
+@bot.on_message(filters.command(["song", "requestsong"], prefixes=config.COMMAND_PREFIXES) & user_in_group_on_filter)
+async def start_song_request_cmd(_, message):
+    """
+    Handles the /song command to initiate a song search.
+    """
+    user_id = message.from_user.id
+
+    if not navidrome_api:
+        await sendMessage(message, "⚠️ Navidrome service is not configured or available. Please contact an admin.")
+        return
+
+    # Cleanup previous search state for the user, if any
+    await cleanup_user_search_state(user_id)
+
+    text = "🎶 **Song Search** 🎶\n\nPlease send me the name of the song, album, or artist you're looking for."
+    
+    # Ask for search query
+    q = await callListen(message, text, timeout=SONG_SEARCH_TIMEOUT)
+    if q.isTimeout:
+        await sendMessage(message, "Song search timed out. Please try again.")
+        return
+    if not q.text: # User sent cancel or something weird
+        await deleteMessage(q) # Delete the prompt message
+        return
+    
+    query_text = q.text.strip()
+    await deleteMessage(q) # Delete the prompt message asking for query
+
+    # Store initial search state
+    user_song_search_data[user_id] = {
+        "query": query_text,
+        "page": 1,
+        "results": None, # Will be populated by display_search_results
+        "message_id": None, # Will be set by display_search_results
+        "search_type": "all" # Default search type: "all", "song", "album", "artist"
+    }
+
+    # Show "Searching..." message
+    searching_msg = await sendMessage(message, f"🔎 Searching Navidrome for: `{query_text}`...")
+    
+    await display_song_search_results(message, user_id, initial_search_msg_id=searching_msg.id)
+
+
+# --- Display Search Results ---
+async def display_song_search_results(original_message_or_call, user_id, initial_search_msg_id=None):
+    """
+    Fetches search results from Navidrome and displays them to the user.
+    Manages pagination and inline keyboards.
+    """
+    if user_id not in user_song_search_data:
+        errmsg = "Search session expired or not found. Please start a new search."
+        if isinstance(original_message_or_call, CallbackQuery):
+            await callAnswer(original_message_or_call, errmsg, alert=True)
+        else:
+            await sendMessage(original_message_or_call, errmsg)
+        return
+
+    state = user_song_search_data[user_id]
+    query = state["query"]
+    page = state["page"]
+    search_type = state.get("search_type", "all") # song, album, artist, all
+
+    # Fetch results from Navidrome
+    # For simplicity, search3 is used. It returns artists, albums, songs.
+    # We can filter display based on search_type state if user chooses later.
+    raw_results = await navidrome_api.search3(query=query, song_count=25, album_count=15, artist_count=10)
+
+    if not raw_results or raw_results.get("status") == "failed" or "subsonic-response" not in raw_results:
+        error_msg = raw_results.get("error", "Failed to fetch results from Navidrome.")
+        LOGGER.error(f"Navidrome search failed for query '{query}': {error_msg}")
+        msg_content = f"⚠️ Error searching Navidrome: {error_msg}\nPlease try again later."
+        if initial_search_msg_id:
+             await editMessage(original_message_or_call.chat.id, initial_search_msg_id, msg_content)
+        elif isinstance(original_message_or_call, CallbackQuery):
+            await editMessage(original_message_or_call.message, msg_content)
+        else: # Should be original message
+            await sendMessage(original_message_or_call, msg_content)
+        await cleanup_user_search_state(user_id)
+        return
+
+    search_result_data = raw_results.get("subsonic-response", {}).get("searchResult3", {})
+    state["results"] = search_result_data # Store full results
+
+    songs = search_result_data.get("song", [])
+    albums = search_result_data.get("album", [])
+    artists = search_result_data.get("artist", [])
+    
+    # Filter based on search_type
+    display_items = []
+    current_item_type_name = "Results"
+
+    if search_type == "song":
+        display_items = songs
+        current_item_type_name = "Songs"
+    elif search_type == "album":
+        display_items = albums
+        current_item_type_name = "Albums"
+    elif search_type == "artist":
+        display_items = artists
+        current_item_type_name = "Artists"
+    else: # "all" - for now, let's prioritize songs, then albums. Artists listed separately.
+        # This part can be more sophisticated. For now, just pick one for primary display.
+        if songs:
+            display_items = songs
+            current_item_type_name = "Songs"
+            state["current_display_type"] = "song" # Track what's being paginated
+        elif albums:
+            display_items = albums
+            current_item_type_name = "Albums"
+            state["current_display_type"] = "album"
+        elif artists:
+            display_items = artists # Less likely to be primary if songs/albums exist
+            current_item_type_name = "Artists"
+            state["current_display_type"] = "artist"
+        else: # No results in any category
+            msg_content = f"🤷 No results found for `{query}` on Navidrome."
+            if initial_search_msg_id:
+                await editMessage(original_message_or_call.chat.id, initial_search_msg_id, msg_content)
+            elif isinstance(original_message_or_call, CallbackQuery): # from original_message_or_call.message
+                 await editMessage(original_message_or_call.message, msg_content)
+            else:
+                 await sendMessage(original_message_or_call, msg_content)
+            await cleanup_user_search_state(user_id)
+            return
+
+    # Pagination for the primary display_items
+    total_items = len(display_items)
+    start_index = (page - 1) * ITEMS_PER_PAGE
+    end_index = start_index + ITEMS_PER_PAGE
+    paginated_items = display_items[start_index:end_index]
+
+    # --- Build Message Content ---
+    text = f"🎶 **Navidrome Search Results for:** `{query}`\n"
+    text += f"Displaying **{current_item_type_name}** (Page {page} of {((total_items -1) // ITEMS_PER_PAGE) + 1})\n\n"
+
+    buttons = []
+    if not paginated_items and page == 1: # No items of the current display type
+        text += f"No {current_item_type_name.lower()} found for this query.\n"
+    
+    for i, item in enumerate(paginated_items):
+        item_id = item.get('id')
+        item_type_short = state.get("current_display_type", "song") # song, album, artist
+
+        if item_type_short == "song":
+            text += f"{start_index + i + 1}. {format_song_details(item)}\n\n"
+            buttons.append([InlineKeyboardButton(f"▶️ {item.get('title', 'N/A')[:30]}", callback_data=f"song_view_{user_id}_{item_type_short}_{item_id}")])
+        elif item_type_short == "album":
+            text += f"{start_index + i + 1}. {format_album_details(item)}\n\n"
+            buttons.append([InlineKeyboardButton(f"💿 {item.get('name', 'N/A')[:30]}", callback_data=f"song_view_{user_id}_{item_type_short}_{item_id}")])
+        elif item_type_short == "artist": # Artists usually don't have direct 'view' with cover art in this simple list
+            text += f"{start_index + i + 1}. {format_artist_details(item)}\n\n"
+            # No specific action button for artist in this iteration, could list their albums.
+
+    # --- Pagination Buttons ---
+    pagination_buttons = []
+    if page > 1:
+        pagination_buttons.append(InlineKeyboardButton("⬅️ Previous", callback_data=f"song_page_prev_{user_id}"))
+    if end_index < total_items:
+        pagination_buttons.append(InlineKeyboardButton("Next ➡️", callback_data=f"song_page_next_{user_id}"))
+    
+    if pagination_buttons:
+        buttons.append(pagination_buttons)
+
+    # --- Filter Buttons (if in "all" mode and other results exist) ---
+    # This is a simplified filter. A more robust one might change state["search_type"]
+    # and re-call display_song_search_results.
+    filter_buttons = []
+    current_display = state.get("current_display_type")
+    if search_type == "all": # Only show filter if initial search was 'all'
+        if songs and current_display != "song":
+            filter_buttons.append(InlineKeyboardButton("🎵 Show Songs", callback_data=f"song_filter_{user_id}_song"))
+        if albums and current_display != "album":
+            filter_buttons.append(InlineKeyboardButton("💿 Show Albums", callback_data=f"song_filter_{user_id}_album"))
+        if artists and current_display != "artist":
+            filter_buttons.append(InlineKeyboardButton("🎤 Show Artists", callback_data=f"song_filter_{user_id}_artist"))
+    
+    if filter_buttons:
+        buttons.append(filter_buttons)
+
+
+    buttons.append([InlineKeyboardButton("❌ Cancel Search", callback_data=f"song_search_cancel_{user_id}")])
+    reply_markup = InlineKeyboardMarkup(buttons) if buttons else None
+
+    # --- Send / Edit Message ---
+    # Attempt to send cover art for the first item if it's a song or album
+    # This is done only once per display, not on pagination for now to reduce spam
+    # and only if it's the first page of that item type.
+    cover_art_id_to_fetch = None
+    photo_to_send = None
+
+    if page == 1 and paginated_items:
+        first_item = paginated_items[0]
+        item_type = state.get("current_display_type")
+        if item_type in ["song", "album"]:
+            cover_art_id_to_fetch = first_item.get('coverArt', first_item.get('id') if item_type == "album" else None) # Songs might use album's cover ID
+            if item_type == "song" and not cover_art_id_to_fetch: # If song has no direct coverArt, try its albumId for cover
+                cover_art_id_to_fetch = first_item.get('albumId')
+
+    if cover_art_id_to_fetch:
+        LOGGER.info(f"Attempting to fetch cover art ID: {cover_art_id_to_fetch} for item type: {item_type}")
+        image_bytes = await navidrome_api.get_cover_art(cover_id=cover_art_id_to_fetch, size=300) # size can be adjusted
+        if image_bytes:
+            photo_to_send = BytesIO(image_bytes)
+            photo_to_send.name = f"cover_{cover_art_id_to_fetch}.png"
+    
+    chat_id = original_message_or_call.chat.id if not isinstance(original_message_or_call, CallbackQuery) else original_message_or_call.message.chat.id
+
+    if initial_search_msg_id: # This is the first display after "Searching..."
+        await deleteMessage(chat_id, initial_search_msg_id) # Delete "Searching..."
+        if photo_to_send:
+            sent_msg = await sendPhoto(
+                chat_id=chat_id,
+                photo=photo_to_send,
+                caption=text,
+                reply_markup=reply_markup
+            )
+        else:
+            sent_msg = await sendMessage(original_message_or_call, text, reply_markup=reply_markup)
+        user_song_search_data[user_id]["message_id"] = sent_msg.id
+    
+    elif isinstance(original_message_or_call, CallbackQuery): # Subsequent updates (pagination, filter)
+        # Don't resend photo on simple pagination for now, just edit text.
+        # If we wanted to change photo based on selected item, logic would be more complex.
+        try:
+            # If current message is a photo, edit caption, else edit text
+            current_msg = original_message_or_call.message
+            if current_msg.photo and photo_to_send: # If we want to update photo on filter
+                 await deleteMessage(current_msg) # Delete old photo message
+                 new_msg = await sendPhoto(chat_id, photo=photo_to_send, caption=text, reply_markup=reply_markup)
+                 user_song_search_data[user_id]["message_id"] = new_msg.id
+            elif current_msg.photo and not photo_to_send: # Switching from photo to text only
+                await deleteMessage(current_msg)
+                new_msg = await sendMessage(original_message_or_call.message, text, reply_markup=reply_markup)
+                user_song_search_data[user_id]["message_id"] = new_msg.id
+            elif not current_msg.photo and photo_to_send: # Switching from text to photo
+                 await deleteMessage(current_msg)
+                 new_msg = await sendPhoto(chat_id, photo=photo_to_send, caption=text, reply_markup=reply_markup)
+                 user_song_search_data[user_id]["message_id"] = new_msg.id
+            else: # Text to Text edit
+                await editMessage(original_message_or_call.message, text, reply_markup=reply_markup)
+        except Exception as e:
+            LOGGER.error(f"Error editing message for song search: {e}")
+            # If edit fails, try sending a new message (e.g. if original message was deleted)
+            # This might happen if the message is too old or bot was restarted.
+            if user_id in user_song_search_data and user_song_search_data[user_id].get("message_id"):
+                new_msg = await sendMessage(original_message_or_call.message, text, reply_markup=reply_markup)
+                user_song_search_data[user_id]["message_id"] = new_msg.id
+
+
+# --- Callback Query Handlers ---
+
+@bot.on_callback_query(filters.regex("^song_page_(next|prev)_(\d+)"))
+async def song_page_callback(_, call):
+    action_type = call.matches[0].group(1)
+    user_id = int(call.matches[0].group(2))
+
+    if user_id not in user_song_search_data or call.from_user.id != user_id:
+        await callAnswer(call, "This is not your search or it has expired.", alert=True)
+        return
+
+    state = user_song_search_data[user_id]
+    if action_type == "next":
+        state["page"] += 1
+    elif action_type == "prev":
+        state["page"] -= 1
+    
+    await callAnswer(call, f"Loading page {state['page']}...")
+    await display_song_search_results(call, user_id)
+
+
+@bot.on_callback_query(filters.regex("^song_filter_(\d+)_(song|album|artist)"))
+async def song_filter_callback(_, call):
+    user_id = int(call.matches[0].group(1))
+    filter_type = call.matches[0].group(2)
+
+    if user_id not in user_song_search_data or call.from_user.id != user_id:
+        await callAnswer(call, "This is not your search or it has expired.", alert=True)
+        return
+    
+    state = user_song_search_data[user_id]
+    state["search_type"] = filter_type # This is what main display will look for
+    state["current_display_type"] = filter_type # Explicitly set what is being paginated
+    state["page"] = 1 # Reset to first page for new filter type
+
+    await callAnswer(call, f"Filtering for {filter_type}s...")
+    await display_song_search_results(call, user_id, initial_search_msg_id=None) # initial_search_msg_id is None as we are editing
+
+
+@bot.on_callback_query(filters.regex("^song_view_(\d+)_(song|album|artist)_([a-zA-Z0-9\-]+)"))
+async def song_view_item_callback(_, call):
+    user_id = int(call.matches[0].group(1))
+    item_type = call.matches[0].group(2)
+    item_id = call.matches[0].group(3)
+
+    if user_id not in user_song_search_data or call.from_user.id != user_id:
+        await callAnswer(call, "This is not your search or it has expired.", alert=True)
+        return
+
+    state = user_song_search_data[user_id]
+    results = state.get("results")
+    if not results:
+        await callAnswer(call, "Search results not found. Please try a new search.", alert=True)
+        return
+
+    item_to_display = None
+    # Find the item in the stored results
+    source_list = results.get(item_type, []) # 'song', 'album', 'artist'
+    for item in source_list:
+        if item.get('id') == item_id:
+            item_to_display = item
+            break
+    
+    if not item_to_display:
+        await callAnswer(call, "Could not find details for the selected item.", alert=True)
+        LOGGER.error(f"Item ID {item_id} of type {item_type} not found in user {user_id}'s stored results.")
+        return
+
+    text = ""
+    cover_art_id = item_to_display.get('coverArt', item_to_display.get('id') if item_type != "song" else None)
+    if item_type == "song" and not cover_art_id: # If song has no direct coverArt, try its albumId for cover
+        cover_art_id = item_to_display.get('albumId')
+
+
+    if item_type == "song":
+        text = format_song_details(item_to_display)
+    elif item_type == "album":
+        text = format_album_details(item_to_display)
+        # Potentially list songs in album here too, if desired (would need another API call like getAlbum)
+    elif item_type == "artist":
+        text = format_artist_details(item_to_display)
+        # Potentially list albums by artist here (would need getArtist -> getAlbums by artist)
+
+    # For "View Details", we will try to send a new message with cover art and details.
+    # The original search list remains as is.
+    
+    photo_to_send = None
+    if cover_art_id:
+        image_bytes = await navidrome_api.get_cover_art(cover_id=cover_art_id, size=500)
+        if image_bytes:
+            photo_to_send = BytesIO(image_bytes)
+            photo_to_send.name = f"cover_detail_{cover_art_id}.png"
+
+    detail_message_text = f"✨ **Item Details** ✨\n\n{text}"
+    
+    # Send as a new message, auto-delete after some time?
+    # This keeps the main search results intact.
+    if photo_to_send:
+        sent_detail_msg = await sendPhoto(
+            chat_id=call.message.chat.id,
+            photo=photo_to_send,
+            caption=detail_message_text,
+            # No buttons for this detail view for now, could add "Back to search"
+        )
+    else:
+        sent_detail_msg = await sendMessage(call.message, detail_message_text)
+    
+    await callAnswer(call, "Displaying details...")
+    # Auto-delete this detail message after a while to keep chat clean
+    asyncio.create_task(auto_delete_message(sent_detail_msg, delay_seconds=180))
+
+
+@bot.on_callback_query(filters.regex("^song_search_cancel_(\d+)"))
+async def song_search_cancel_callback(_, call):
+    user_id = int(call.matches[0].group(1))
+
+    if user_id not in user_song_search_data or call.from_user.id != user_id:
+        await callAnswer(call, "This is not your search.", alert=True)
+        return
+
+    await callAnswer(call, "Search cancelled.")
+    try:
+        if user_song_search_data[user_id].get("message_id"):
+            await deleteMessage(call.message.chat.id, user_song_search_data[user_id]["message_id"])
+    except Exception as e:
+        LOGGER.error(f"Error deleting song search message on cancel: {e}")
+    await cleanup_user_search_state(user_id)
+
+
+LOGGER.info("SakuraEmbyManager: Navidrome Song Request Panel loaded.")
+
+# TODO:
+# - Consider more sophisticated display for "all" results (e.g., sections for songs, albums, artists in one message).
+# - Add "request" functionality if needed (e.g., send to admin, add to playlist - this is not specified in current task).
+# - Refine error messages and user feedback.
+# - The `user_in_group_on_filter` might need adjustment based on actual bot structure.
+# - `fix_bottons.বাটপ্যাড` usage if it's a more complex button layout helper. For now, using InlineKeyboardMarkup directly.
+# - Test cover art logic thoroughly, especially for songs (album art fallback).
+# - Test message editing logic (photo to text, text to photo, etc.)
+# - Ensure `config.COMMAND_PREFIXES` is correctly used or adapt if it's a single prefix.
+# - The `auto_delete_message` for detail view is a good UX touch.
+# - For artist view, one might want to trigger another search for their albums/songs.
+# - If `callListen` doesn't delete its prompt automatically on text received, ensure it's handled. (It seems it is based on `request_movie_panel.py` usually)
+# - What to do if `navidrome_api.search3` returns an empty list for song/album/artist but status is ok? Handled by "No results found".
+# - The `filters.regex("^song_view_(\d+)_(song|album|artist)_([a-zA-Z0-9\-]+)")` for item_id might need to be more general if IDs can have other characters. Subsonic IDs are usually alphanumeric.
+# - The `initial_search_msg_id` handling is to replace "Searching..." correctly.
+# - When filtering (e.g. "Show Songs"), the photo display logic might need to re-evaluate if a photo should be shown for the new list's first item. (Added basic logic for this)
+# - Consider using `bot.name` or similar for logging context if available.
+# - The `user_in_group_on_filter` is assumed to be available. If not, basic `filters.private` or `filters.group` might be used.
+# - The `search_type` vs `current_display_type` in state: `search_type` is what user selected (all, song, album, artist). `current_display_type` is what is *actually* being paginated if `search_type` was 'all' and we defaulted to showing songs first.
+# - `CallbackQuery` is not defined, it should be `from pyrogram.types import CallbackQuery`
+# - `COMMAND_PREFIXES` should be `config.COMMAND_PREFIXES` if it's from config, or define it. Assuming it's from `bot.config`.
+# - `auto_delete_message` needs to be imported or defined. Assuming it's from `msg_utils`.
+# - `deleteMessage` might need `message.chat.id, message.id` if it's just `message`. (Corrected for `initial_search_msg_id`)
+# - `editMessage` takes `message_or_chat_id, message_id, text` or `message_instance, text`. (Corrected for clarity)
+# - `sendMessage` takes `chat_id_or_message_instance, text`. (Corrected for clarity)
+
+# Final check on imports and pyrogram types
+from pyrogram.types import CallbackQuery # Added this explicitly.
+
+# Assuming config.COMMAND_PREFIXES is a list or string, e.g. ['/', '!'] or '/'
+if not hasattr(config, 'COMMAND_PREFIXES'):
+    LOGGER.warning("config.COMMAND_PREFIXES not found, using default '/'")
+    config.COMMAND_PREFIXES = "/"

--- a/config_example.json
+++ b/config_example.json
@@ -78,6 +78,12 @@
     "access_token": null,
     "price": 1
   },
+  "navidrome": {
+    "navidrome_url": "http://localhost:4533",
+    "navidrome_username": "",
+    "navidrome_password": "",
+    "navidrome_app_name": "SakuraEmbyBossBot"
+  },
   "auto_update": {
     "status": true,
     "git_repo": "berry8838/Sakura_embyboss",


### PR DESCRIPTION
This commit introduces a new feature allowing you to search for and view details of songs, albums, and artists from a configured Navidrome server.

Key components added:
- Navidrome API client (`bot/func_helper/navidrome.py`): Handles communication with the Navidrome (Subsonic) API, including authentication, search, and cover art retrieval.
- Song Request Panel (`bot/modules/panel/request_song_panel.py`): Provides the Telegram bot interface for the `/song` command, user input, results display (with pagination and filtering), and detail view with cover art.
- Configuration: New `navidrome` section in `config_example.json`.

The feature is integrated into the bot's existing panel structure and utilizes established patterns for your interaction and API communication.